### PR TITLE
Using `test` scope for `org.junit.vintage`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit-vintage-engine.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
There is (probably) no need to have `junit` outside of the `test` scope, therefore setting the dependency as such.