### PR TITLE
Enrich exception based logs

### DIFF
--- a/src/main/java/com/contentstack/sdk/CSBackgroundTask.java
+++ b/src/main/java/com/contentstack/sdk/CSBackgroundTask.java
@@ -1,5 +1,6 @@
 package com.contentstack.sdk;
 
+import java.util.logging.Level;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
@@ -82,7 +83,7 @@ class CSBackgroundTask {
             try {
                 throw new IllegalAccessException("CSBackgroundTask Header Exception");
             } catch (IllegalAccessException e) {
-                logger.severe(e.getLocalizedMessage());
+                logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
             }
         }
     }

--- a/src/main/java/com/contentstack/sdk/CSHttpConnection.java
+++ b/src/main/java/com/contentstack/sdk/CSHttpConnection.java
@@ -1,5 +1,6 @@
 package com.contentstack.sdk;
 
+import java.util.logging.Level;
 import okhttp3.ResponseBody;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
@@ -177,7 +178,7 @@ public class CSHttpConnection implements IURLRequestHTTP {
         try {
             getService(url);
         } catch (IOException | JSONException e) {
-            logger.severe(e.getLocalizedMessage());
+            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
         }
     }
 

--- a/src/main/java/com/contentstack/sdk/Constants.java
+++ b/src/main/java/com/contentstack/sdk/Constants.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -89,7 +90,7 @@ public class Constants {
             try {
                 return parseDate(date, formatString, timeZone);
             } catch (ParseException e) {
-                logger.warning(e.getLocalizedMessage());
+                logger.log(Level.WARNING, e.getLocalizedMessage(), e);
             }
         }
         return null;

--- a/src/main/java/com/contentstack/sdk/EntriesModel.java
+++ b/src/main/java/com/contentstack/sdk/EntriesModel.java
@@ -1,5 +1,6 @@
 package com.contentstack.sdk;
 
+import java.util.logging.Level;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -31,7 +32,7 @@ class EntriesModel {
             }
         } catch (Exception e) {
             Logger logger = Logger.getLogger(EntriesModel.class.getSimpleName());
-            logger.severe(e.getLocalizedMessage());
+            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
         }
 
     }

--- a/src/main/java/com/contentstack/sdk/Entry.java
+++ b/src/main/java/com/contentstack/sdk/Entry.java
@@ -1,5 +1,6 @@
 package com.contentstack.sdk;
 
+import java.util.logging.Level;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -482,7 +483,7 @@ public class Entry {
             String value = getString(key);
             return Constants.parseDate(value, null);
         } catch (Exception e) {
-            logger.severe(e.getLocalizedMessage());
+            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
         }
         return null;
     }
@@ -504,7 +505,7 @@ public class Entry {
             String value = getString("created_at");
             return Constants.parseDate(value, null);
         } catch (Exception e) {
-            logger.severe(e.getLocalizedMessage());
+            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
         }
         return null;
     }
@@ -541,7 +542,7 @@ public class Entry {
             String value = getString("updated_at");
             return Constants.parseDate(value, null);
         } catch (Exception e) {
-            logger.severe(e.getLocalizedMessage());
+            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
         }
         return null;
     }
@@ -580,7 +581,7 @@ public class Entry {
             String value = getString("deleted_at");
             return Constants.parseDate(value, null);
         } catch (Exception e) {
-            logger.severe(e.getLocalizedMessage());
+            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
         }
         return null;
     }
@@ -739,7 +740,7 @@ public class Entry {
                         entryInstance = contentType.stackInstance.contentType(refContentType).entry();
                     } catch (Exception e) {
                         entryInstance = new Entry(refContentType);
-                        logger.severe(e.getLocalizedMessage());
+                        logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
                     }
                     entryInstance.setUid(model.uid);
                     entryInstance.resultJson = model.jsonObject;
@@ -952,7 +953,7 @@ public class Entry {
             try {
                 throw new IllegalAccessException("Entry Uid is required");
             } catch (IllegalAccessException e) {
-                logger.severe(e.getLocalizedMessage());
+                logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
             }
         }
         String urlString = "content_types/" + contentTypeUid + "/entries/" + uid;

--- a/src/main/java/com/contentstack/sdk/Group.java
+++ b/src/main/java/com/contentstack/sdk/Group.java
@@ -1,5 +1,6 @@
 package com.contentstack.sdk;
 
+import java.util.logging.Level;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -272,7 +273,7 @@ public class Group {
             String value = getString(key);
             return Constants.parseDate(value, null);
         } catch (Exception e) {
-            logger.severe(e.getLocalizedMessage());
+            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
         }
         return null;
     }
@@ -389,7 +390,7 @@ public class Group {
                             entryInstance = stackInstance.contentType(refContentType).entry();
                         } catch (Exception e) {
                             entryInstance = new Entry(refContentType);
-                            logger.severe(e.getLocalizedMessage());
+                            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
                         }
                         entryInstance.setUid(model.uid);
                         entryInstance.resultJson = model.jsonObject;
@@ -400,7 +401,7 @@ public class Group {
                 }
             }
         } catch (Exception e) {
-            logger.severe(e.getLocalizedMessage());
+            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
             return entryContainer;
         }
         return entryContainer;

--- a/src/main/java/com/contentstack/sdk/Query.java
+++ b/src/main/java/com/contentstack/sdk/Query.java
@@ -1,5 +1,6 @@
 package com.contentstack.sdk;
 
+import java.util.logging.Level;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -1210,7 +1211,7 @@ public class Query implements INotifyClass {
             mainJSON.put(QUERY, urlQueries);
             fetchFromNetwork(urlString, mainJSON, callback, callBack);
         } catch (Exception e) {
-            logger.severe(e.getLocalizedMessage());
+            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
             throwException("find", Constants.QUERY_EXCEPTION, e);
         }
 

--- a/src/main/java/com/contentstack/sdk/QueryResult.java
+++ b/src/main/java/com/contentstack/sdk/QueryResult.java
@@ -1,5 +1,6 @@
 package com.contentstack.sdk;
 
+import java.util.logging.Level;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -108,7 +109,7 @@ public class QueryResult {
             }
 
         } catch (Exception e) {
-            logger.severe(e.getLocalizedMessage());
+            logger.log(Level.SEVERE, e.getLocalizedMessage(), e);
         }
     }
 


### PR DESCRIPTION
## Description
We noticed some log events in our system with `null` message. That seems to be coming from this SDK, there I noticed that you're simply logging the localized message. However since the message itself is a nullable property, and some exceptions might not provide it, would be great if we can enrich the logs with the exception itself to get a bit more clarity on what actually happened. 

Happy to get any feedback on this.

## Actions taken
- passing exception object into logging pipeline instead of relying only on message / localized message being there

### Note
Please note that this was simply a search & replace for places where there is a direct use of localized message in a log statement. 