### PR TITLE
Handle missing error code (0 as default)

### DIFF
--- a/src/main/java/com/contentstack/sdk/CSHttpConnection.java
+++ b/src/main/java/com/contentstack/sdk/CSHttpConnection.java
@@ -305,7 +305,14 @@ public class CSHttpConnection implements IURLRequestHTTP {
         responseJSON.put(ERROR_MESSAGE, responseJSON.optString(ERROR_MESSAGE));
         responseJSON.put(ERROR_CODE, responseJSON.optString(ERROR_CODE));
         responseJSON.put(ERRORS, responseJSON.optString(ERRORS));
-        int errCode = Integer.parseInt(responseJSON.optString(ERROR_CODE));
+
+        int errCode = 0;
+        try {
+            errCode = Integer.parseInt(responseJSON.optString(ERROR_CODE));
+        } catch (NumberFormatException e) {
+            // in case of missing error code, we keep it 0
+        }
+
         connectionRequest.onRequestFailed(responseJSON, errCode, callBackObject);
     }
 

--- a/src/test/java/com/contentstack/sdk/CSHttpConnectionTest.java
+++ b/src/test/java/com/contentstack/sdk/CSHttpConnectionTest.java
@@ -1,0 +1,41 @@
+package com.contentstack.sdk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class CSHttpConnectionTest {
+
+  static class MockIRequestModelHTTP implements IRequestModelHTTP {
+    public JSONObject error;
+    public int statusCode;
+
+    @Override
+    public void sendRequest() {
+      // Do nothing
+    }
+
+    @Override
+    public void onRequestFailed(JSONObject error, int statusCode, ResultCallBack callBackObject) {
+      this.error = error;
+      this.statusCode = statusCode;
+    }
+
+    @Override
+    public void onRequestFinished(CSHttpConnection request) {
+      // Do nothing
+    }
+  };
+
+  @Test
+  void setError() {
+    MockIRequestModelHTTP csConnectionRequest = new MockIRequestModelHTTP();
+
+    CSHttpConnection connection = new CSHttpConnection("https://www.example.com", csConnectionRequest);
+    connection.setError("Something bad");
+
+    assertEquals("Something bad", csConnectionRequest.error.getString("error_message"));
+    assertEquals(0, csConnectionRequest.statusCode);
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/contentstack/contentstack-java/issues/161

I did not see any mocking library in use, so i created a simple static class