### PR TITLE
fix(deps): security update — 1 package(s) [risk: LOW]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.1</version>
+            <version>2.21.2</version>
         </dependency>
         <dependency>
             <groupId>com.slack.api</groupId>


### PR DESCRIPTION
## Security Fix — SnykrAI

### Verification
- [x] Dependencies resolve
- [x] Build passes (`mvn compile -q`)
- [x] Tests pass (`mvn test -q`)

### Risk: LOW
> Patch-level upgrade. Bug/security fixes only, safe to merge.

### Vulnerabilities Addressed

**HIGH: Allocation of Resources Without Limits or Throttling**
| Detail | Value |
|--------|-------|
| Package | `com.fasterxml.jackson.core:jackson-core@2.21.1` |
| Dependency type | Transitive |
| CWE | [CWE-770](https://cwe.mitre.org/data/definitions/770.html) |
| CVSS | 8.7 |
| Vulnerable range | `[2.8.0,2.21.2)` |
| Fixed in | `2.21.2` |
| Snyk ID | `SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551` |
| Published | 2026-04-05 |

### Dependency Upgrades
| Package | From | To | Risk | Reasoning |
|---------|------|----|------|-----------|
| `com.fasterxml.jackson.core:jackson-databind` | 2.21.1 | 2.21.2 | patch | Upgrading jackson-databind to 2.21.2 as specified in Snyk's fixed_in field; jackson-core is part of the same Jackson ... |

### Changelog & Impact Analysis

<details>
<summary><strong>com.fasterxml.jackson.core:jackson-databind</strong> (2.21.1 → 2.21.2)</summary>

**Registry:** https://central.sonatype.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.21.2

_No changelog available from registry. Manual review recommended._

</details>

### Not Fixed — Remediation Guidance

• **com.fasterxml.jackson.core:jackson-core@2.21.1** — **Wait for upstream fix**: Since jackson-core is a transitive dependency of jackson-databind, the practical path is to upgrade jackson-databind to 2.21.2, which will pull in the corrected jackson-core version transitively. Monitor the jackson-databind 2.21.2 release to confirm the aligned jackson-core dependency, then update your pom.xml accordingly.

### Metadata
| | |
|---|---|
| LLM Provider | anthropic |
| Strategy | conservative |
| Total issues | 2 |
| Fixable | 1 |
| Ecosystem | maven |
| Generated | 2026-04-21 05:34 UTC |

---
_Automated by SnykrAI — draft PR, needs human review before merging._